### PR TITLE
Update MudListExtended.razor.cs

### DIFF
--- a/CodeBeam.MudBlazor.Extensions/Components/ListExtended/MudListExtended.razor.cs
+++ b/CodeBeam.MudBlazor.Extensions/Components/ListExtended/MudListExtended.razor.cs
@@ -1156,13 +1156,14 @@ namespace MudExtensions
                 _allSelected = true;
             }
 
+            var selectedItems = items.Where(x => x.IsSelected).Select(y => y.Value).ToHashSet(_comparer);
             if (ItemCollection != null)
             {
-                SelectedValues = deselect == true ? Enumerable.Empty<T>() : ItemCollection.ToHashSet(_comparer);
+                SelectedValues = deselect == true ? Enumerable.Empty<T>() : selectedItems;
             }
             else
             {
-                SelectedValues = items.Where(x => x.IsSelected).Select(y => y.Value).ToHashSet(_comparer);
+                SelectedValues = selectedItems;
             }
 
             if (MudSelectExtended != null)


### PR DESCRIPTION
- Change the behaviour of the MudListExtended component, so that "Select All" only selects all of the items currently filtered in the dropdown. 
- Fixed https://github.com/CodeBeamOrg/CodeBeam.MudBlazor.Extensions/issues/273